### PR TITLE
Change deprecated method GetUnityTargetName()

### DIFF
--- a/UnityPluginExample/Assets/Plugins/iOS/Editor/BuildPostProcessor.cs
+++ b/UnityPluginExample/Assets/Plugins/iOS/Editor/BuildPostProcessor.cs
@@ -18,7 +18,7 @@ public class BuildPostProcessor
             project.ReadFromFile(projectPath);
 
             // Get targetGUID
-            var targetName = PBXProject.GetUnityTargetName();
+            var targetName = project.GetUnityFrameworkTargetGuid();
             var targetGUID = project.TargetGuidByName(targetName);
 
             // Built in Frameworks


### PR DESCRIPTION
GetUnityTargetName is deprecated, there are two targets now, call GetUnityMainTargetGuid() - for app or GetUnityFrameworkTargetGuid() - for source/plugins to get Guid.